### PR TITLE
Update default packet size

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The `import-chunks.sh` script allows you to import chunked SQL files with memory
 - `-w, --password PASS` - Database password
 - `-n, --database NAME` - Database name
 - `-h, --host HOST` - Database host (default: local socket)
-- `-m, --max-packet SIZE` - Max allowed packet size in bytes (default: 1073741824)
+- `-m, --max-packet SIZE` - Max allowed packet size in bytes (default: 2147483648)
 - `-s, --sleep SECONDS` - Sleep time between chunks in seconds (default: 3)
 - `--help` - Display help message
 

--- a/import-chunks.sh
+++ b/import-chunks.sh
@@ -10,7 +10,7 @@ DB_PASS=""
 DB_NAME=""
 DB_HOST=""  # Empty means use local socket
 SLEEP_SECONDS=3  # Sleep time between chunks
-MAX_PACKET="2073741824"  # Default max allowed packet size (2GB)
+MAX_PACKET="2147483648"  # Default max allowed packet size (2GB)
 MOVE_IMPORTED=false
 COMPLETED_DIR=""
 
@@ -24,7 +24,7 @@ usage() {
   echo "  -p, --password PASS   Database password"
   echo "  -d, --database NAME   Database name (default: )"
   echo "  -h, --host HOST       Database host (default: local socket)"
-  echo "  -m, --max-packet SIZE Max allowed packet size in bytes (default: 2073741824)"
+  echo "  -m, --max-packet SIZE Max allowed packet size in bytes (default: 2147483648)"
   echo "  -s, --sleep SECONDS   Sleep time between chunks in seconds (default: 3)"
   echo "  --path DIRECTORY      Directory containing chunk files (default: ./chunks)"
   echo "  --dry-run             Show what would be imported without actually importing"


### PR DESCRIPTION
## Summary
- update default max packet constant to 2147483648
- update help text
- adjust README documentation

## Testing
- `bash -n import-chunks.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to reflect the new default maximum packet size for importing chunked SQL files (now 2 GiB).

- **Chores**
  - Increased the default maximum allowed packet size in the import script to 2 GiB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->