### PR TITLE
Improve shell script reliability

### DIFF
--- a/chunk-large-export.sh
+++ b/chunk-large-export.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Default values
 CHUNK_SIZE=200  # Number of INSERT statements per chunk

--- a/export-database.sh
+++ b/export-database.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Default values
 DB_USER="root"

--- a/import-chunks.sh
+++ b/import-chunks.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Default values
 DRY_RUN=false

--- a/import-database.sh
+++ b/import-database.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Default values
 DB_USER="root"

--- a/remove-super-statements-from-chunks.sh
+++ b/remove-super-statements-from-chunks.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Default values
 CHUNKS_DIR="./chunks"


### PR DESCRIPTION
## Summary
- enforce `set -euo pipefail` at the top of all `.sh` scripts to exit on errors and catch undefined variables

## Testing
- `bash -n chunk-large-export.sh`
- `bash -n export-database.sh`
- `bash -n import-chunks.sh`
- `bash -n import-database.sh`
- `bash -n remove-super-statements-from-chunks.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved error handling in several scripts to enhance reliability and robustness during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->